### PR TITLE
Update Nucleus: Object

### DIFF
--- a/library/src/Nucleus/Object/Object.c
+++ b/library/src/Nucleus/Object/Object.c
@@ -28,7 +28,7 @@ destroy
         Nucleus_Object *self
     );
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Object_Class *dispatch
@@ -88,7 +88,7 @@ destroy
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Object_Class *dispatch

--- a/library/src/Nucleus/Object/ObjectArray.c
+++ b/library/src/Nucleus/Object/ObjectArray.c
@@ -6,14 +6,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Object_Library_Export,
                             Nucleus_ObjectArray,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_ObjectArray_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_ObjectArray_Class *dispatch

--- a/library/src/Nucleus/Object/ObjectArrayEnumerator.c
+++ b/library/src/Nucleus/Object/ObjectArrayEnumerator.c
@@ -25,7 +25,7 @@ nextObject
         Nucleus_ObjectEnumerator *self
     );
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_ObjectArrayEnumerator_Class *dispatch
@@ -37,7 +37,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_ObjectArrayEnumerator_Class *dispatch

--- a/library/src/Nucleus/Object/ObjectEnumerator.c
+++ b/library/src/Nucleus/Object/ObjectEnumerator.c
@@ -6,7 +6,7 @@ Nucleus_ClassTypeDefinition(Nucleus_Object_Library_Export,
                             Nucleus_ObjectEnumerator,
                             Nucleus_Object)
                             
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_ObjectEnumerator_Class *dispatch
@@ -18,7 +18,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_ObjectEnumerator_Class *dispatch

--- a/library/src/Nucleus/Object/String.c
+++ b/library/src/Nucleus/Object/String.c
@@ -25,7 +25,7 @@ hash
         Nucleus_HashValue *hashValue
     );
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_String_Class *dispatch
@@ -36,7 +36,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_String_Class *dispatch

--- a/library/src/Nucleus/Object/Types.h
+++ b/library/src/Nucleus/Object/Types.h
@@ -68,7 +68,7 @@ Nucleus_Types_addClassType
 			NameCxx *self \
 		); \
 \
-    Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status \
+    Nucleus_NonNull() static Nucleus_Status \
     constructDispatch \
         ( \
             NameCxx##_Class *dispatch \

--- a/test/Signals/src/Nucleus.Object.Test.Signals/A.c
+++ b/test/Signals/src/Nucleus.Object.Test.Signals/A.c
@@ -7,14 +7,14 @@ Nucleus_ClassTypeDefinition(Export,
                             A,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         A_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         A_Class *dispatch


### PR DESCRIPTION
Update annotations: As signals constructors and dispatch
constructors are not required to succceed anymore, the
Nucleus_AlwaysSucceed() annotation was removed from them.