### PR TITLE
Reduce namespace pollution (Windows)

### DIFF
--- a/library/src/Nucleus/Object/DynamicLibraryWindows.h
+++ b/library/src/Nucleus/Object/DynamicLibraryWindows.h
@@ -6,15 +6,17 @@
 #if (Nucleus_OperatingSystem == Nucleus_OperatingSystem_WINDOWS)
 
 #include "Nucleus/Object/DynamicLibrary.h"
-#include "Nucleus/IncludesWindows.h"
+
 
 typedef struct Nucleus_DynamicLibraryWindows Nucleus_DynamicLibraryWindows;
 #define NUCLEUS_DYNAMICLIBRARYWINDOWS(p) ((Nucleus_DynamicLibraryWindows *)(p))
 
+typedef struct Nucleus_DynamicLibraryWindowsImpl Nucleus_DynamicLibraryWindowsImpl;
+
 struct Nucleus_DynamicLibraryWindows
 {
     Nucleus_DynamicLibrary parent;
-    HINSTANCE handle;
+	Nucleus_DynamicLibraryWindowsImpl *pimpl;
 }; // struct Nucleus_DynamicLibraryWindows
 
 Nucleus_NonNull() Nucleus_Status


### PR DESCRIPTION
Include directives of Windows-specific headers in header files of
this library caused leakage of Windows-specific declarations and
definitions into the namespaces of unrelated parts of this library
and into the namespaces of the consumers of this library. This
was fixed by moving these Windows-specific include directives
from the library header files into the library source files.
Consequently, Windows-specific implementation code had to
be moved as well from the library header files into the library
source files. This was done by applying the PIMPL (Pointer to
IMPLementation) pattern.