### PR TITLE
Update Nucleus: Object

### DIFF
--- a/library/src/Nucleus/Object/Object.c.i
+++ b/library/src/Nucleus/Object/Object.c.i
@@ -14,6 +14,15 @@ __Nucleus_Objects_initialize
     status = Nucleus_Types_initialize();
     if (Nucleus_Unlikely(status)) return status;
     //
+#if defined(Nucleus_WithSignals) && 1 == Nucleus_WithSignals
+    status = Nucleus_Signals_initialize();
+    if (Nucleus_Unlikely(status))
+    {
+        Nucleus_Types_uninitialize();
+        return status;
+    }
+#endif
+    //
     module->referenceCount = 1;
     //
     return Nucleus_Status_Success;
@@ -25,6 +34,9 @@ __Nucleus_Objects_uninitialize
         Nucleus_Objects *module
     )
 {
+#if defined(Nucleus_WithSignals) && 1 == Nucleus_WithSignals
+    Nucleus_Signals_uninitialize();
+#endif
     Nucleus_Types_uninitialize();
     return Nucleus_Status_Success;
 }


### PR DESCRIPTION
Nucleus_Objects_(un)initialize (un)initializes Nucleus_Types and
Nucleus_Signals in proper order.